### PR TITLE
Updates asynchronous tracing samples

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -19,35 +19,44 @@
     <dependencies>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-annotations</artifactId>
+            <version>${pinpoint.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-profiler</artifactId>
             <version>${pinpoint.version}</version>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-profiler-optional-jdk6</artifactId>
+            <artifactId>pinpoint-profiler-test</artifactId>
             <version>${pinpoint.version}</version>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-profiler-optional-jdk7</artifactId>
+            <artifactId>pinpoint-profiler-optional</artifactId>
             <version>${pinpoint.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-profiler-optional-jdk8</artifactId>
-            <version>${pinpoint.version}</version>
+            <scope>runtime</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-plugins</artifactId>
             <version>${pinpoint.version}</version>
-            <type>zip</type>
+            <type>pom</type>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>plugin-sample-plugin</artifactId>
+            <version>${pinpoint.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core-optional</artifactId>
             <version>${pinpoint.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/agent/src/assembly/distribution.xml
+++ b/agent/src/assembly/distribution.xml
@@ -26,28 +26,26 @@
     </dependencySet>
     <dependencySet>
         <includes>
+            <include>com.navercorp.pinpoint:pinpoint-annotations</include>
+            <include>com.navercorp.pinpoint:pinpoint-commons</include>
             <include>com.navercorp.pinpoint:pinpoint-bootstrap-core</include>
+            <include>com.navercorp.pinpoint:pinpoint-bootstrap-core-optional</include>
         </includes>
         <outputDirectory>boot</outputDirectory>
     </dependencySet>
     <dependencySet>
         <excludes>
+            <exclude>com.navercorp.pinpoint:pinpoint-annotations</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-commons</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-bootstrap-core</exclude>
+            <exclude>com.navercorp.pinpoint:pinpoint-bootstrap-core-optional</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-bootstrap</exclude>
             <exclude>com.navercorp.pinpoint:pinpoint-plugins</exclude>
-            <exclude>com.navercorp.pinpoint:plugin-sample-plugin</exclude>
+            <exclude>*:pom</exclude>
         </excludes>
         <outputDirectory>lib</outputDirectory>
         <useProjectArtifact>false</useProjectArtifact>
         <useTransitiveFiltering>true</useTransitiveFiltering>
-    </dependencySet>
-    <dependencySet>
-        <includes>
-            <include>com.navercorp.pinpoint:pinpoint-plugins</include>
-        </includes>
-        <outputDirectory>plugin</outputDirectory>
-        <unpack>true</unpack>
     </dependencySet>
     <dependencySet>
         <includes>

--- a/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/AsyncInitiatorInterceptor.java
+++ b/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/AsyncInitiatorInterceptor.java
@@ -14,7 +14,7 @@
  */
 package com.navercorp.pinpoint.plugin.sample._12_Asynchronous_Trace;
 
-import com.navercorp.pinpoint.bootstrap.context.AsyncTraceId;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
@@ -48,18 +48,15 @@ public class AsyncInitiatorInterceptor implements AroundInterceptor1 {
         recorder.recordServiceType(SamplePluginConstants.MY_SERVICE_TYPE);
         recorder.recordApi(descriptor, new Object[] { arg0 });
 
-        // To trace async invocations, you have to get async trace id like below.
-        AsyncTraceId asyncTraceId = trace.getAsyncTraceId();
+        // To trace async invocations, you have to create AsyncContext like below, automatically attaching it to the current span event.
+        AsyncContext asyncContext = recorder.recordNextAsyncContext();
         
-        // Then record the AsyncTraceId as next async id. 
-        recorder.recordNextAsyncId(asyncTraceId.getAsyncId());
-        
-        // Finally, you have to pass the AsyncTraceId to the thread which handles the async task.
-        // How to do that depends on the target library implementation.
+        // Finally, you have to pass the AsyncContext to the thread which handles the async task.
+        // How to do this depends on the target library implementation.
         // 
         // In this sample, we set the id as scope invocation attachment like below to pass it to the constructor interceptor of TargetClass12_Worker which has run() method that handles the async task.
-        // Then the constructor interceptor will get the attached id and set to the initializing TargetClass12_Worker object.
-        scope.getCurrentInvocation().setAttachment(asyncTraceId);
+        // Then the constructor interceptor will get the attached AsyncContext and set to the initializing TargetClass12_Worker object.
+        scope.getCurrentInvocation().setAttachment(asyncContext);
     }
 
     @Override

--- a/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/Sample_12_Asynchronous_Trace.java
+++ b/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/Sample_12_Asynchronous_Trace.java
@@ -16,14 +16,12 @@ package com.navercorp.pinpoint.plugin.sample._12_Asynchronous_Trace;
 
 import java.security.ProtectionDomain;
 
-import com.navercorp.pinpoint.bootstrap.async.AsyncTraceIdAccessor;
-import com.navercorp.pinpoint.bootstrap.context.AsyncTraceId;
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
 import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
 import com.navercorp.pinpoint.bootstrap.instrument.InstrumentException;
 import com.navercorp.pinpoint.bootstrap.instrument.InstrumentMethod;
 import com.navercorp.pinpoint.bootstrap.instrument.Instrumentor;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallback;
-import com.navercorp.pinpoint.bootstrap.interceptor.SpanAsyncEventSimpleAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
 import com.navercorp.pinpoint.plugin.sample.SamplePluginConstants;
@@ -32,14 +30,25 @@ import static com.navercorp.pinpoint.common.util.VarArgs.va;
 
 /**
  * To trace an async invocation you have to
- * 
- * 1. Intercept a method initiating an async task and issues a new {@link AsyncTraceId}.
- * 2. Pass the AsyncTraceId to the handler of the async task. 
- * 3. Add a field with {@link AsyncTraceIdAccessor} to the class handling the async task.   
- * 4. Intercept a method handling the async task with an interceptor extending {@link SpanAsyncEventSimpleAroundInterceptor}
- * 
- * 
- * In this sample, {@link AsyncInitiator} transforms TargetClass12_AsyncInitiator, which initiates async task as its name says.
+ * <ol>
+ *     <li>
+ *         Intercept a method initiating an async task and create/record a new
+ *         {@link com.navercorp.pinpoint.bootstrap.context.AsyncContext AsyncContext}.
+ *     </li>
+ *     <li>
+ *         Pass the <tt>AsyncContext</tt> to the handler of the async task.
+ *     </li>
+ *     <li>
+ *         Add a field with {@link AsyncContextAccessor} to the class handling the async task.
+ *     </li>
+ *     <li>
+ *         Intercept a method handling the async task with an interceptor extending
+ *         {@link com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventSimpleAroundInterceptor
+ *         AsyncContextSpanEventSimpleAroundInterceptor}.
+ *     </li>
+ * </ol>
+ *
+ * In this sample, {@link AsyncInitiator} transforms TargetClass12_AsyncInitiator, which initiates async task.
  * {@link Worker} transforms TargetClass12_Worker, which handles async task initiated by TargetClass12_AsyncInitiator.
  */
 public class Sample_12_Asynchronous_Trace {
@@ -67,7 +76,7 @@ public class Sample_12_Asynchronous_Trace {
             InterceptorScope scope = instrumentor.getInterceptorScope(SCOPE_NAME);
             
             InstrumentClass target = instrumentor.getInstrumentClass(classLoader, className, classfileBuffer);
-            target.addField("com.navercorp.pinpoint.bootstrap.async.AsyncTraceIdAccessor");
+            target.addField(AsyncContextAccessor.class.getName());
             
             InstrumentMethod constructor = target.getConstructor("java.lang.String", "com.navercorp.plugin.sample.target.TargetClass12_Future");
             constructor.addScopedInterceptor("com.navercorp.pinpoint.plugin.sample._12_Asynchronous_Trace.WorkerConstructorInterceptor", scope, ExecutionPolicy.INTERNAL);

--- a/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/WorkerConstructorInterceptor.java
+++ b/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/WorkerConstructorInterceptor.java
@@ -14,14 +14,15 @@
  */
 package com.navercorp.pinpoint.plugin.sample._12_Asynchronous_Trace;
 
-import com.navercorp.pinpoint.bootstrap.async.AsyncTraceIdAccessor;
-import com.navercorp.pinpoint.bootstrap.context.AsyncTraceId;
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor2;
 import com.navercorp.pinpoint.bootstrap.interceptor.annotation.IgnoreMethod;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
 
 /**
- * This interceptor get AsyncTraceId from interceptor scope invocation attachment and set it to the initializing object through AsyncTraceIdAccessor
+ * This interceptor retrieves <tt>AsyncContext</tt> from interceptor scope invocation attachment and sets it to
+ * <tt>this</tt> object through {@link AsyncContextAccessor}.
  */
 public class WorkerConstructorInterceptor implements AroundInterceptor2 {
     private final InterceptorScope scope;
@@ -38,7 +39,7 @@ public class WorkerConstructorInterceptor implements AroundInterceptor2 {
 
     @Override
     public void after(Object target, Object arg0, Object arg1, Object result, Throwable throwable) {
-        AsyncTraceId asyncTraceId = (AsyncTraceId)scope.getCurrentInvocation().getAttachment();
-        ((AsyncTraceIdAccessor)target)._$PINPOINT$_setAsyncTraceId(asyncTraceId);
+        AsyncContext asyncContext = (AsyncContext) scope.getCurrentInvocation().getAttachment();
+        ((AsyncContextAccessor) target)._$PINPOINT$_setAsyncContext(asyncContext);
     }
 }

--- a/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/WorkerRunInterceptor.java
+++ b/plugin/src/main/java/com/navercorp/pinpoint/plugin/sample/_12_Asynchronous_Trace/WorkerRunInterceptor.java
@@ -14,35 +14,36 @@
  */
 package com.navercorp.pinpoint.plugin.sample._12_Asynchronous_Trace;
 
-import com.navercorp.pinpoint.bootstrap.async.AsyncTraceIdAccessor;
-import com.navercorp.pinpoint.bootstrap.context.AsyncTraceId;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
-import com.navercorp.pinpoint.bootstrap.interceptor.SpanAsyncEventSimpleAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventSimpleAroundInterceptor;
 import com.navercorp.pinpoint.plugin.sample.SamplePluginConstants;
 
 /**
  * This interceptor intercepts run() method, which handles the async task.
  * 
- * Pinpoint provides {@link SpanAsyncEventSimpleAroundInterceptor} which handles all the chores related to the async trace.
- * You can extends it and forget about all the async things except for one.
- * {@link SpanAsyncEventSimpleAroundInterceptor} retrieves {@link AsyncTraceId} from the target objcet through {@link AsyncTraceIdAccessor}.
- * Therefore you have to add it to the target class by {@link InstrumentClass#addField(String)}.
- * Of course, don't forget setting AsyncTraceIdAccessor before this interceptor is executed.
- * In this sample, {@link WorkerConstructorInterceptor} takes care of it. 
+ * Pinpoint provides {@link AsyncContextSpanEventSimpleAroundInterceptor} which handles all the chores related to
+ * continuing traces beyond thread boundaries.
+ * <br/>
+ * {@link AsyncContextSpanEventSimpleAroundInterceptor} retrieves the {@link AsyncContext} from the target (this) object
+ * via {@link com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor AsyncContextAccessor}.
+ * Therefore the target class <strong>must</strong> be transformed to be an instance of <tt>AsyncContextAccessor</tt>
+ * and have the <tt>AsyncContext</tt> field.
+ * <br/>
+ * In this sample, {@link WorkerConstructorInterceptor} sets the <tt>AsyncContext</tt> to <tt>this</tt> object.
  * 
  * @author Jongho Moon
  */
-public class WorkerRunInterceptor extends SpanAsyncEventSimpleAroundInterceptor {
+public class WorkerRunInterceptor extends AsyncContextSpanEventSimpleAroundInterceptor {
 
     public WorkerRunInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
         super(traceContext, methodDescriptor);
     }
 
     @Override
-    protected void doInBeforeTrace(SpanEventRecorder recorder, AsyncTraceId asyncTraceId, Object target, Object[] args) {
+    protected void doInBeforeTrace(SpanEventRecorder recorder, AsyncContext asyncContext, Object target, Object[] args) {
         // do nothing
     }
 


### PR DESCRIPTION
Asynchronous tracing APIs have changed dramatically in 1.7.0, and the samples do not work anymore.
This updates the samples to include these changes.